### PR TITLE
Prevent memory leak by flushing WP cache after each batch

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -174,6 +174,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 				$order_data = $next_batch;
 				$batch_count++;
 			}
+			wp_cache_flush();
 		}
 
 		$progress->finish();


### PR DESCRIPTION
Will impact site performance during migration. Might be needed on backfill as well but not yet tested.